### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,9 @@ jobs:
           cat .env
           docker pull "${IMAGE}":${{ matrix.qgis_version_tag }}
           python admin.py build --tests
-          docker-compose up -d
+          docker compose up -d
           sleep 10
 
       - name: Run test suite
         run: |
-          docker-compose exec -T qgis-testing-environment qgis_testrunner.sh test_suite.test_package
+          docker compose exec -T qgis-testing-environment qgis_testrunner.sh test_suite.test_package

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   qgis-testing-environment:
     image: ${IMAGE}:${QGIS_VERSION_TAG}
     volumes:
-      - ./build/plugin_name:/tests_directory:rw
+      - ./build/qgis_plugin_template:/tests_directory:rw
     environment:
       QGIS_VERSION_TAG: "${QGIS_VERSION_TAG}"
       WITH_PYTHON_PEP: "${WITH_PYTHON_PEP}"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -17,12 +17,12 @@ do
     export ON_TRAVIS=false
     export MUTE_LOGS=true
 
-    docker-compose up -d
+    docker compose up -d
 
     sleep 10
-    docker-compose exec -T qgis-testing-environment sh -c "pip3 install flask"
+    docker compose exec -T qgis-testing-environment sh -c "pip3 install flask"
 
-    docker-compose exec -T qgis-testing-environment qgis_testrunner.sh test_suite.test_package
-    docker-compose down
+    docker compose exec -T qgis-testing-environment qgis_testrunner.sh test_suite.test_package
+    docker compose down
 
 done


### PR DESCRIPTION
Updates the used docker command removing the old and deprecated `docker-compose`. These changes also change the plugin name used in linking it to the tests directory.