### PR TITLE
Workflow to handle pull request packages

### DIFF
--- a/.github/workflows/pr_package.yml
+++ b/.github/workflows/pr_package.yml
@@ -1,0 +1,85 @@
+name: Plugin zip package
+
+on:
+  pull_request:
+    types:
+      - edited
+      - opened
+      - reopened
+      - synchronize
+    branches:
+      - develop
+
+jobs:
+  create-package:
+    runs-on: ubuntu-22.04
+    container:
+      image: qgis/qgis:release-3_34
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Fix Python command
+        run: apt-get install python-is-python3
+
+      - name: Install python
+        uses: actions/setup-python@v4
+
+      - name: Install plugin dependencies
+        run: |
+          pip install -r requirements_dev.txt
+
+      - name: Get unique identifier
+        id: get-identifier
+        run: |
+          echo "PACKAGE_ID=$(python -c "import uuid; print(str(uuid.uuid4())[:4])")" >> $GITHUB_ENV
+
+      - name: Set Git configuration
+        run: |
+          git config --global --add safe.directory /__w/qgis-plugin-template/qgis-plugin-template
+
+      - name: Build zipfile
+        run: |
+          
+          python admin.py build --output-directory ${{ format(
+          './qgis-plugin-template_{0}_{1}/qgis_plugin_template/',
+          github.event.pull_request.head.ref,
+          env.PACKAGE_ID) }}
+          
+          echo "ZIP_PATH=$GITHUB_WORKSPACE/${{ format('qgis-plugin-template_{0}_{1}', github.event.pull_request.head.ref, env.PACKAGE_ID) }}" >> $GITHUB_ENV
+          echo "ZIP_NAME=${{ format('qgis-plugin-template_{0}_{1}', github.event.pull_request.head.ref, env.PACKAGE_ID) }}" >> $GITHUB_ENV
+          
+
+      - name: Uploading plugin build
+        id: artifact-upload-step
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ZIP_NAME }}
+          path: ${{ env.ZIP_PATH }}
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.number }}
+          comment-author: 'github-actions[bot]'
+
+      - name: Update Comment
+        env:
+          HEAD_SHA: "${{ github.event.head_sha }}"
+          ARTIFACT_URL: ${{ steps.artifact-upload-step.outputs.artifact-url }}
+
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          token: ${{ github.token }}
+          issue-number: ${{ github.event.number }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          edit-mode: replace
+          body: |-
+            ![badge]
+            
+            Plugin zip package for the changes in this PR has been successfully built!.
+            
+            Download the plugin zip file here ${{ env.ARTIFACT_URL }}
+            
+            [badge]: https://img.shields.io/badge/package_build-success-green


### PR DESCRIPTION
Fixes https://github.com/Samweli/qgis-plugin-template/issues/1

Implementing a workflow to create a pull request artifact and add a comment in the corresponding pull request comment section. The artifact can be used to test the introduced changes, once downloaded the artifact can be installed inside QGIS  as a plugin zip file. 

**Note**: The workflow will only be able to add a comment if the repository and organization actions/policy settings allow write permission for workflow comments on pull requests.