### PR TITLE
Updated packaging workflows

### DIFF
--- a/.github/workflows/comment_pr_package.yml
+++ b/.github/workflows/comment_pr_package.yml
@@ -1,0 +1,107 @@
+name: Add comment on a pull request about the plugin package
+# Based on work from https://github.com/orgs/community/discussions/51403#discussioncomment-5535167
+on:
+  workflow_run:
+    types:
+      - completed
+    workflows:
+      - 'Creating plugin package in the PR'
+
+jobs:
+  comment:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for 10 seconds
+        run: sleep 10
+
+      - name: List all available artifact
+        run: |
+          echo "Listing all artifacts for the past workflow run"
+
+          # Get the past workflow run ID
+          run_id=${{ github.event.workflow_run.id }}
+          repo=${{ github.repository }}
+
+          response=$(curl -s \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/$repo/actions/runs/$run_id/artifacts")
+
+          # Extract artifact names from the response
+          artifact_names=$(echo "$response" | jq -r '.artifacts[].name')
+
+          # Display the artifact names
+          echo "Artifacts:"
+          echo "$artifact_names"
+
+      - name: Download artifacts
+        run: |
+          mkdir -p artifacts
+          
+          # Get the past workflow run ID
+          run_id=${{ github.event.workflow_run.id }}
+          repo=${{ github.repository }}
+          
+          # Fetch all artifact download URLs
+          ARTIFACT_URLS=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+               "https://api.github.com/repos/$repo/actions/runs/$run_id/artifacts" \
+            | jq -r '.artifacts[] | select(.expired == false) | .archive_download_url')
+          
+          # Download each artifact using artifact ID
+          echo "$ARTIFACT_URLS" | while read -r url; do
+            ARTIFACT_ID=$(echo "$url" | cut -d'/' -f9)  # Extract artifact ID from URL
+            echo "Downloading artifact ID: $ARTIFACT_ID"
+            curl -L -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -o "artifacts/${ARTIFACT_ID}.zip" "$url"
+          done
+
+          echo "all artifacts: $ARTIFACT_URLS"
+
+      - name: Extract all artifacts
+        run: |
+          for zip in artifacts/*.zip; do
+            unzip -o "$zip" -d artifacts
+          done
+
+      - name: List extracted Files
+        run: ls -lah artifacts
+
+      - name: Read the pr number artifact
+        id: pr_number_reader
+        run: |
+          PR_NUMBER=$(cat artifacts/pr_number.txt)
+          echo "PR number: $PR_NUMBER"
+          echo "::set-output name=pr_number::$PR_NUMBER"
+
+      - name: Read the artifact URL
+        id: artifact_url_reader
+        run: |
+          ARTIFACT_URL=$(cat artifacts/artifact_url.txt)
+          echo "Artifact URL: $ARTIFACT_URL"
+          echo "::set-output name=artifact_url::$ARTIFACT_URL"
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: find-comment
+        with:
+          issue-number: ${{ steps.pr_number_reader.outputs.pr_number }}
+          comment-author: 'github-actions[bot]'
+      - name: Update Comment
+        env:
+          ARTIFACT_URL: "${{ steps.artifact_url_reader.outputs.artifact_url }}"
+          HEAD_SHA: "${{ github.event.head_sha }}"
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          token: ${{ github.token }}
+          issue-number:  ${{ steps.pr_number_reader.outputs.pr_number }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          edit-mode: replace
+          body: |-
+            ![badge]
+            
+            Plugin zip package for the changes in this PR has been successfully built!.
+            
+            Download the plugin zip file from here ${{ env.ARTIFACT_URL }}
+            
+            [badge]: https://img.shields.io/badge/package_build-success-green

--- a/.github/workflows/pr_package.yml
+++ b/.github/workflows/pr_package.yml
@@ -57,29 +57,23 @@ jobs:
           name: ${{ env.ZIP_NAME }}
           path: ${{ env.ZIP_PATH }}
 
-      - name: Find Comment
-        uses: peter-evans/find-comment@v2
-        id: find-comment
-        with:
-          issue-number: ${{ github.event.number }}
-          comment-author: 'github-actions[bot]'
-
-      - name: Update Comment
+      - name: Save the artifact url and pull request number
+        shell: bash
         env:
-          HEAD_SHA: "${{ github.event.head_sha }}"
+          PR_NUMBER: ${{ github.event.number }}
           ARTIFACT_URL: ${{ steps.artifact-upload-step.outputs.artifact-url }}
+        run: |
+          echo $ARTIFACT_URL > artifact_url.txt
+          echo $PR_NUMBER > pr_number.txt
 
-        uses: peter-evans/create-or-update-comment@v3
+      - name: Upload the artifact url
+        uses: actions/upload-artifact@v4
         with:
-          token: ${{ github.token }}
-          issue-number: ${{ github.event.number }}
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          edit-mode: replace
-          body: |-
-            ![badge]
-            
-            Plugin zip package for the changes in this PR has been successfully built!.
-            
-            Download the plugin zip file here ${{ env.ARTIFACT_URL }}
-            
-            [badge]: https://img.shields.io/badge/package_build-success-green
+          name: artifact_url
+          path: ./artifact_url.txt
+
+      - name: Upload the PR number
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr_number
+          path: ./pr_number.txt


### PR DESCRIPTION
Update the Github actions artifact upload/download. The API for the actions steps has been updated from v3 to v4. This breaks most of the project workflow. See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions